### PR TITLE
test: test_custom_shell.py, test_read unittest 작성

### DIFF
--- a/tests/test_custom_shell.py
+++ b/tests/test_custom_shell.py
@@ -1,3 +1,6 @@
+import io
+
+from contextlib import redirect_stdout
 from unittest import TestCase, skip
 from unittest.mock import Mock
 
@@ -13,9 +16,11 @@ class TestCustomShell(TestCase):
         ssd = Mock()
         test_tables = {0: "0x00000000", 50: "0xAABBCCDD", 99: "0xAABBCCD0"}
         for lba, data in test_tables.items():
-            with self.subTest(f"lba: {lba}, ssd data read test!"):
+            with (self.subTest(f"lba: {lba}, ssd data read test!"),
+                  io.StringIO() as buf, redirect_stdout(buf)):
                 ssd.read.return_value = data
-                self.assertEqual(CustomShell().read(lba), data)
+                CustomShell().read(lba)
+                self.assertEqual(buf.getvalue().strip(), data)
 
     def test_exit(self):
         pass

--- a/tests/test_custom_shell.py
+++ b/tests/test_custom_shell.py
@@ -1,4 +1,7 @@
 from unittest import TestCase
+from unittest.mock import Mock
+
+from custom_shell.custom_shell import CustomShell
 
 
 class TestCustomShell(TestCase):
@@ -6,7 +9,9 @@ class TestCustomShell(TestCase):
         pass
 
     def test_read(self):
-        pass
+        ssd = Mock()
+        ssd.read.return_value = "0xAABBCCDD"
+        self.assertEqual(CustomShell().read(0), "0xAABBCCDD")
 
     def test_exit(self):
         pass

--- a/tests/test_custom_shell.py
+++ b/tests/test_custom_shell.py
@@ -22,6 +22,13 @@ class TestCustomShell(TestCase):
                 CustomShell().read(lba)
                 self.assertEqual(buf.getvalue().strip(), data)
 
+    @skip
+    def test_exception_when_invalid_argument_for_read(self):
+        test_lbas = [-1, 101, '10', '', ' ', None]
+        for lba in test_lbas:
+            with self.assertRaises(ValueError):
+                CustomShell().read(lba)
+
     def test_exit(self):
         pass
 

--- a/tests/test_custom_shell.py
+++ b/tests/test_custom_shell.py
@@ -11,8 +11,11 @@ class TestCustomShell(TestCase):
     @skip
     def test_read(self):
         ssd = Mock()
-        ssd.read.return_value = "0xAABBCCDD"
-        self.assertEqual(CustomShell().read(0), "0xAABBCCDD")
+        test_tables = {0: "0x00000000", 50: "0xAABBCCDD", 99: "0xAABBCCD0"}
+        for lba, data in test_tables.items():
+            with self.subTest(f"lba: {lba}, ssd data read test!"):
+                ssd.read.return_value = data
+                self.assertEqual(CustomShell().read(lba), data)
 
     def test_exit(self):
         pass

--- a/tests/test_custom_shell.py
+++ b/tests/test_custom_shell.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from unittest import TestCase, skip
 from unittest.mock import Mock
 
 from custom_shell.custom_shell import CustomShell
@@ -8,6 +8,7 @@ class TestCustomShell(TestCase):
     def test_write(self):
         pass
 
+    @skip
     def test_read(self):
         ssd = Mock()
         ssd.read.return_value = "0xAABBCCDD"


### PR DESCRIPTION
아직 ssd가 개발되지 않아서 Double사용하였고
파일(result.txt)을 읽은 결과를 비교하기에 string type으로 비교하였습니다.