### PR TITLE
[fix] if shell args is empty, do continue.

### DIFF
--- a/custom_shell/custom_shell.py
+++ b/custom_shell/custom_shell.py
@@ -5,6 +5,8 @@ class CustomShell:
     def session(self) -> None:
         while True:
             args = input().split()
+            if len(args) == 0: continue
+
             method = getattr(self, args[0], None)
             if callable(method):
                 try:


### PR DESCRIPTION
shell에서 빈 enter 입력시 args[0] out of range 발생하여 pass시키는 코드입니다.