### PR TITLE
[feat] Custom Shell write 기능 구현

### DIFF
--- a/custom_shell/custom_shell.py
+++ b/custom_shell/custom_shell.py
@@ -1,3 +1,6 @@
+import os
+
+
 class CustomShell:
     def session(self) -> None:
         while True:
@@ -13,9 +16,23 @@ class CustomShell:
             else:
                 print("INVALID COMMAND")
 
+    def ssd_command(self, cmd: str) -> None:
+        os.system(cmd)
+
     def write(self,
               lba: int,
-              val: int) -> bool:
+              val: str) -> bool:
+        # lba = int(lba)
+
+        if not (0 <= int(lba) <= 99):
+            print("LBA is out of range [0, 100).")
+            return True
+        if not val.startswith("0x") or len(val) != 10:
+            print("invalid VAL format.")
+            return True
+
+        self.ssd_command(f"python ../ssd/ssd.py W {lba} {val}")
+
         return True
 
     def read(self,


### PR DESCRIPTION
변경 사항
- write 함수 파라미터 val 타입 변경 (int -> str)
- lba, val 예외처리
- os.system 사용한 ssd write 전달
- unittest 에서 mock 사용하여 예외처리 검증