### PR TITLE
refactor: quotation convention

### DIFF
--- a/custom_shell/custom_shell.py
+++ b/custom_shell/custom_shell.py
@@ -12,7 +12,7 @@ class CustomShell:
                  src_path: str = os.path.join(os.path.dirname(__file__), "../ssd/result.txt")) -> None:
         self.__src_path = src_path
 
-        with open(os.path.dirname(__file__) + "/help.txt", 'r') as file:
+        with open(os.path.dirname(__file__) + "/help.txt", "r") as file:
             self.__help_content = file.read()
 
     def session(self) -> None:

--- a/ssd/ssd.py
+++ b/ssd/ssd.py
@@ -93,7 +93,7 @@ class SSD(ISSD):
             raise ValueError("LBA is out of range [0, 100).")
 
         with open(self._result_path, "w") as f:
-            f.write(f'0x{self._data[lba]:08X}')
+            f.write(f"0x{self._data[lba]:08X}")
 
 
 def ssd(*args):
@@ -102,13 +102,13 @@ def ssd(*args):
     my_ssd = SSD()
 
     op = args[1]
-    assert op in ('R', 'W'), "Only 'R' and 'W' are supported."
+    assert op in ("R", "W"), "Only 'R' and 'W' are supported."
 
     lba = int(args[2])
-    if op == 'R':
+    if op == "R":
         my_ssd.read(lba)
 
-    if op == 'W':
+    if op == "W":
         val = args[3]
         my_ssd.write(lba, val)
 

--- a/tests/test_custom_shell.py
+++ b/tests/test_custom_shell.py
@@ -60,7 +60,7 @@ class TestCustomShell(TestCase):
             self.assertFalse(exit_code)
 
     def test_help(self):
-        with open(os.path.dirname(__file__) + "/../custom_shell/help.txt", 'r') as file:
+        with open(os.path.dirname(__file__) + "/../custom_shell/help.txt", "r") as file:
             expected = file.read()
 
         with io.StringIO() as buf, redirect_stdout(buf):
@@ -81,7 +81,7 @@ class TestCustomShell(TestCase):
         with io.StringIO() as buf, redirect_stdout(buf):
             self.__cshell.fullread()
             result = buf.getvalue().strip()
-            expected = '\n'.join(f"[{lba}] - {val}" for lba in range(0, 100))
+            expected = "\n".join(f"[{lba}] - {val}" for lba in range(0, 100))
 
             self.assertEqual(expected, result)
 
@@ -90,5 +90,5 @@ class TestCustomShell(TestCase):
         with io.StringIO() as buf, redirect_stdout(buf):
             self.__cshell.fullread()
             result = buf.getvalue().strip()
-            expected = '\n'.join(_lba_to_sample_val(lba) for lba in range(0, 100))
+            expected = "\n".join(_lba_to_sample_val(lba) for lba in range(0, 100))
             self.assertEqual(expected, result)

--- a/tests/test_ssd.py
+++ b/tests/test_ssd.py
@@ -14,16 +14,16 @@ class TestSSD(TestCase):
         out_of_range_lbas = (-100, -3, -1, 100, 111, 145)
         for lba in out_of_range_lbas:
             with self.assertRaises(ValueError):
-                self.__ssd.write(lba, '0x00000100')
+                self.__ssd.write(lba, "0x00000100")
 
     def test_mismatch_type_lba_write(self):
         invalid_lbas = ("x", None)
         for lba in invalid_lbas:
             with self.assertRaises(TypeError):
-                self.__ssd.write(lba, '0x00000100')
+                self.__ssd.write(lba, "0x00000100")
 
     def test_out_of_range_val_write(self):
-        out_of_range_vals = ('-0x10', '-0x1', '0x100000000', '0x123456789', '0xABCDABCD0', '0x1234', '0xFFFFFF')
+        out_of_range_vals = ("-0x10", "-0x1", "0x100000000", "0x123456789", "0xABCDABCD0", "0x1234", "0xFFFFFF")
         for val in out_of_range_vals:
             with self.assertRaises(ValueError):
                 self.__ssd.write(0x0, val)


### PR DESCRIPTION
쌍따옴표 빈도가 많아서 문자열은 쌍따옴표로 통일하였습니다.
오늘 하루도 수고 많으셨습니다.