### PR TITLE
[feat] cshell erase 예외 케이스 테스트 추가 및 오류 수정

### DIFF
--- a/custom_shell/commands.py
+++ b/custom_shell/commands.py
@@ -80,7 +80,7 @@ class EraseSizeCommand(ICommand):
 
     def execute(self) -> None:
         EraseRangeCommand(self._start_lba,
-                          self._start_lba + self._size - 1).execute()
+                          self._start_lba + self._size).execute()
 
 
 class EraseRangeCommand(ICommand):

--- a/tests/test_custom_shell.py
+++ b/tests/test_custom_shell.py
@@ -119,3 +119,10 @@ class TestCustomShell(TestCase):
             self.assertEqual("INVALID SET OF PARAMETERS PROVIDED FOR 'write'.", result[0])
             self.assertEqual("Use 'help' to see the manual.", result[1])
             self.assertEqual("Exiting session.", result[2])
+
+    @patch("builtins.input", side_effect=["write 1 0x123AFE18", "erase 1 1", "read 1", "exit"])
+    def test_erase_size_just_one_lba(self, mock_input):
+        with io.StringIO() as buf, redirect_stdout(buf):
+            self.__cshell.session()
+            result = buf.getvalue().strip().split("\n")
+            self.assertEqual("[1] - 0x00000000", result[0])


### PR DESCRIPTION
- 기존 cshell에서 `erase 1 1`과 같이 size가 1일 때는 지워지지 않는 오류가 있어 TC를 추가하고 오류를 수정했습니다.