### PR TITLE
feat: flush TC 추가

### DIFF
--- a/custom_ssd/command_buffer.py
+++ b/custom_ssd/command_buffer.py
@@ -34,7 +34,7 @@ class CommandBuffer:
                     index: int) -> ICommand:
         return self.__commands[index]
 
-    def is_full(self) -> bool:
+    def overflows(self) -> bool:
         return len(self) > CommandBuffer.MAX_SIZE
 
     def push(self,
@@ -45,7 +45,7 @@ class CommandBuffer:
 
         self.__optimize_and_queue_new_command(new_command)
 
-        if self.is_full():
+        if self.overflows():
             LOGGER.info(f"Buffer-initiated buffer flush (b/c buffer is full).")
             self.flush()
 

--- a/custom_ssd/command_buffer.py
+++ b/custom_ssd/command_buffer.py
@@ -35,7 +35,7 @@ class CommandBuffer:
         return self.__commands[index]
 
     def is_full(self) -> bool:
-        return len(self) >= CommandBuffer.MAX_SIZE
+        return len(self) > CommandBuffer.MAX_SIZE
 
     def push(self,
              new_command: ICommand) -> None:

--- a/tests/test_custom_shell.py
+++ b/tests/test_custom_shell.py
@@ -141,3 +141,7 @@ class TestCustomShell(TestCase):
             for lba in range(94, 99):
                 self.assertEqual(f"[{lba}] - 0x00000000", result[lba])
             self.assertEqual("[99] - 0x123AFE18", result[99])
+
+    def test_invalid_flush_args(self):
+        with self.assertRaises(TypeError):
+            self.__cshell.execute("flush", 0)

--- a/tests/test_custom_ssd.py
+++ b/tests/test_custom_ssd.py
@@ -1,5 +1,6 @@
 import os
 import itertools
+
 import numpy as np
 from unittest import TestCase
 

--- a/tests/test_custom_ssd.py
+++ b/tests/test_custom_ssd.py
@@ -161,7 +161,7 @@ class TestSSD(TestCase):
         nand_data = ["0x00000000" for _ in range(self.__ssd.LBA_LOWER_BOUND,
                                                      self.__ssd.LBA_UPPER_BOUND + 1)]
 
-        test_vals = ["0x" + format(i, "08X")[:10] for i in range(0, 10, 1)]
+        test_vals = [f"0x{i:08X}" for i in range(0, 10, 1)]
         for lba, val in enumerate(test_vals):
             self.__ssd.queue_command(self.__ssd.command_factory("W", lba, val))
 
@@ -188,7 +188,7 @@ class TestSSD(TestCase):
             self.assertEqual(expected_val, self.__ssd.search(lba))
 
     def test_flush_max_buffer_size_after_optimization(self):
-        test_vals = ["0x" + format(i, "08X")[:10] for i in range(0, 8, 1)]
+        test_vals = [f"0x{i:08X}" for i in range(0, 8, 1)]
         for lba, val in enumerate(test_vals):
             self.__ssd.queue_command(self.__ssd.command_factory("W", lba, val))
 

--- a/tests/test_custom_ssd.py
+++ b/tests/test_custom_ssd.py
@@ -156,3 +156,53 @@ class TestSSD(TestCase):
 
         for lba, expected_val in enumerate(expected_vals):
             self.assertEqual(expected_val, self.__ssd._nand_data[lba])
+
+    def test_flush_max_buffer_size(self):
+        nand_data = ["0x00000000" for _ in range(self.__ssd.LBA_LOWER_BOUND,
+                                                     self.__ssd.LBA_UPPER_BOUND + 1)]
+
+        test_vals = ["0x" + format(i, "08X")[:10] for i in range(0, 10, 1)]
+        for lba, val in enumerate(test_vals):
+            self.__ssd.queue_command(self.__ssd.command_factory("W", lba, val))
+
+        self.assertEqual(10, len(self.__ssd._command_buffer))
+
+        for lba, expected_val in enumerate(test_vals):
+            self.assertEqual(expected_val, self.__ssd.search(lba))
+
+        for lba, expected_val in enumerate(nand_data):
+            self.assertEqual(expected_val, self.__ssd._nand_data[lba])
+
+        test_vals[9] = "0x11111111"
+        self.__ssd.queue_command(self.__ssd.command_factory("W", 9, test_vals[9]))
+        self.assertEqual(10, len(self.__ssd._command_buffer))
+
+        for lba, expected_val in enumerate(test_vals):
+            self.assertEqual(expected_val, self.__ssd.search(lba))
+
+        test_vals.append("0xAAAAAAAA")
+        self.__ssd.queue_command(self.__ssd.command_factory("W", 10, test_vals[10]))
+        self.assertEqual(1, len(self.__ssd._command_buffer))
+
+        for lba, expected_val in enumerate(test_vals):
+            self.assertEqual(expected_val, self.__ssd.search(lba))
+
+    def test_flush_max_buffer_size_after_optimization(self):
+        test_vals = ["0x" + format(i, "08X")[:10] for i in range(0, 8, 1)]
+        for lba, val in enumerate(test_vals):
+            self.__ssd.queue_command(self.__ssd.command_factory("W", lba, val))
+
+        self.assertEqual(8, len(self.__ssd._command_buffer))
+
+        for i in range(0,4):
+            test_vals.append("0x00000000")
+        self.__ssd.queue_command(self.__ssd.command_factory("E", 8, 4))
+
+        self.assertEqual(9, len(self.__ssd._command_buffer))
+
+        test_vals[10] = "0x10101010"
+        self.__ssd.queue_command(self.__ssd.command_factory("W", 10, test_vals[10]))
+        self.assertEqual(1, len(self.__ssd._command_buffer))
+
+        for lba, expected_val in enumerate(test_vals):
+            self.assertEqual(expected_val, self.__ssd.search(lba))


### PR DESCRIPTION
- max buffer size에서 cmd 입력시 (덮어쓰는 명령어 + 새로운 명령어)
- max buffer size - 1에서 명령어가 쪼개져 11개가 되는 경우
- shell에서 invalid flush argument 입력되는 경우